### PR TITLE
Set Bot Status

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,5 +60,7 @@ client.on('message', async message => {
     }
 })
 
-client.login(config.BOT_TOKEN)
+client.login(config.BOT_TOKEN).then(() => {
+    client.user.setActivity('!!help', { type: 'PLAYING' })
+})
 console.log('Clotho is up and running!')


### PR DESCRIPTION
# Summary
This PR is being made to set the bot's status in Discord to the help command, so that users can always figure out how to run it and learn how to use the bot.

# How to Test
1. `yarn && yarn start`
1. Open up Discord
1. Look at Clotho's name on the right side
1. Underneath Clotho's name, it should say "Playing !!help"