### PR TITLE
Reset Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ All of Clotho's commands begin with `!!`, and you can always get a printed summa
 
 <!-- ROADMAP -->
 ## Roadmap
-As of right now, there isn't much else that I want to add. I have one or two quality-of-life commands that I would like to add, and I may come up with a better/more efficient way for the bot to perform its utilities, but at the moment it's working perfectly for my friends and I!
+As of right now, there isn't much else that I want to add. I have one or two quality-of-life things that I would like to add, and I may come up with a better/more efficient way for the bot to perform its utilities, but at the moment it's working perfectly for my friends and I!
 
 See the [open issues](https://github.com/ShowMeTheRoapes/clotho/issues) for a list of proposed features (and known issues).
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ All of Clotho's commands begin with `!!`, and you can always get a printed summa
 | `!!submit`    | Candidate  | Clotho will record your candidate and user information for the open poll.<br>If you submit another candidate, it will replace your current one.<br>Clotho will send you a private message to show you what she received/saved as your submission. |
 | `!!closepoll` | None       | Clotho will no longer accept submissions for the open poll.<br>Clotho will use the StrawPoll API to create a poll with all of the submitted candidates and post the link to it.                                                                 |
 | `!!declare`   | None       | Clotho will inspect the StrawPoll, determine which candidate is the winner, and post a message about it.<br>All poll information will be cleared and a new one may be started.                                                                  |
-
+| `!!reset`   | None       | Reset all poll information to nothing. You'll have a clean slate!                                                                  |
 
 <!-- ROADMAP -->
 ## Roadmap

--- a/actions/help.js
+++ b/actions/help.js
@@ -8,6 +8,7 @@ Here's a list of the valid commands for Clotho!
 **!!submit [candidate for poll]** - Submit your candidate for the current poll. If you have already submitted a candidate, using this command again will replace your submission.
 **!!closepoll** - Stop taking submissions for the current poll and create a StrawPoll with the given candidates.
 **!!declare** - Declares a victor of the StrawPoll and erases the values in the poll object.
+**!!reset** - Resets all poll information to nothing. You have a clean slate!
 
 The typical order for using these commands is the way they are listed above (with the exception of the **!!ping** command).
 `

--- a/actions/index.js
+++ b/actions/index.js
@@ -4,6 +4,7 @@ const submit = require('./submit')
 const closePoll = require('./closepoll')
 const declareVictor = require('./declarevictor')
 const help = require('./help')
+const reset = require('./reset')
 
 module.exports = {
     ping,
@@ -12,4 +13,5 @@ module.exports = {
     closePoll,
     declareVictor,
     help,
+    reset,
 }

--- a/actions/reset.js
+++ b/actions/reset.js
@@ -1,0 +1,14 @@
+const { Message } = require('discord.js')
+const { Poll } = require('../classes')
+
+/**
+ * Reset the poll object so that it has a clean slate.
+ * @param {Poll} poll The Poll object holding all poll information
+ * @param {Message} message The Message object from the Discord.js API
+ */
+function reset(poll, message) {
+    poll.resetPoll()
+    message.channel.send('Poll has been reset! Use the **!!startpoll** command to begin a new one.')
+}
+
+module.exports = reset

--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ client.on('message', async message => {
             await runCommand('Declare Victor', () => actions.declareVictor(poll, message))
             break
 
+        case 'reset':
+            await runCommand('Reset Poll', () => actions.reset(poll, message))
+            break
+
         case 'help':
             await runCommand('Help', () => actions.help(message))
             break


### PR DESCRIPTION
## Summary
As I was updating the README, I noticed that not having a simple interface for resetting the poll was a bit of a bummer, so I decided to make the `!!reset` command. It will completely wipe anything ongoing, so only use it when you definitely want to!

![resetCommand](https://user-images.githubusercontent.com/12129503/103128332-252e8380-4652-11eb-910c-9512788fc658.gif)

If accepted, this PR will:
- Create the `!!reset` command, which allows users to reset Cloth and erase any poll information currently saved
- Add `!!reset` information to the output of the `!!help` command and the README
- Close #7

## How to Test
1. Start up Clotho
2. Go to the Discord server that Clotho is added to
3. Run the `!!startpoll` command with some title
4. Run the `!!reset` command
    * Clotho should reply to let you know that the poll has been reset
5. Try to run the `!!submit` command
    * Clotho should give you an error to let you know that there is no poll to submit a candidate for