### PR TITLE
Create New Strawpoll on Tie

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ All of Clotho's commands begin with `!!`, and you can always get a printed summa
 | `!!startpoll` | Poll Title | Clotho will begin recording information for a poll with the given title.<br>Users will now be able to use the `!!submit` command.                                                                                                                |
 | `!!submit`    | Candidate  | Clotho will record your candidate and user information for the open poll.<br>If you submit another candidate, it will replace your current one.<br>Clotho will send you a private message to show you what she received/saved as your submission. |
 | `!!closepoll` | None       | Clotho will no longer accept submissions for the open poll.<br>Clotho will use the StrawPoll API to create a poll with all of the submitted candidates and post the link to it.                                                                 |
-| `!!declare`   | None       | Clotho will inspect the StrawPoll, determine which candidate is the winner, and post a message about it.<br>All poll information will be cleared and a new one may be started.                                                                  |
+| `!!declare`   | None       | Clotho will inspect the StrawPoll, determine which candidate is the winner, and post a message about it.<br>All poll information will be cleared and a new one may be started.<br><br>**NOTE:** If there is a tie between candidates, a new StrawPoll will be created with only those candidates. |
 | `!!reset`   | None       | Reset all poll information to nothing. You'll have a clean slate!                                                                  |
 
 <!-- ROADMAP -->

--- a/actions/declarevictor.js
+++ b/actions/declarevictor.js
@@ -44,7 +44,7 @@ async function declareVictor(poll, message) {
     if (winner.length > 1) {
         message.channel.send(`There has been a tie between the following candidates: ${winner.map(cand => cand.answer).join(', ')}\nPlease vote again on the tiebreaker StrawPoll provided below!`)
 
-        poll.candidates = poll.candidates.filter(c => winner.some(w => w.answer.toLowerCase() === c.candidate))
+        poll.candidates = poll.candidates.filter(c => winner.some(w => w.answer.toLowerCase() === c.candidate.toLowerCase()))
         const response = await createStrawPoll(poll)
         poll.strawPollId = response.data.content_id
 

--- a/actions/declarevictor.js
+++ b/actions/declarevictor.js
@@ -42,7 +42,7 @@ async function declareVictor(poll, message) {
     }
 
     if (winner.length > 1) {
-        message.channel.send(`There has been a tie between the following candidates: ${winner.map(cand => cand.answer).join(', ')}\nPlease vote again on the tiebreaker StrawPoll provided below!`)
+        message.channel.send(`There has been a tie between the following candidates: ${winner.map(cand => cand.answer).join(' :fire: ')}\nPlease vote again on the tiebreaker StrawPoll provided below!`)
 
         poll.candidates = poll.candidates.filter(c => winner.some(w => w.answer.toLowerCase() === c.candidate.toLowerCase()))
         const response = await createStrawPoll(poll)

--- a/actions/declarevictor.js
+++ b/actions/declarevictor.js
@@ -44,7 +44,15 @@ async function declareVictor(poll, message) {
     if (winner.length > 1) {
         message.channel.send(`There has been a tie between the following candidates: ${winner.map(cand => cand.answer).join(' :fire: ')}\nPlease vote again on the tiebreaker StrawPoll provided below!`)
 
-        poll.candidates = poll.candidates.filter(c => winner.some(w => w.answer.toLowerCase() === c.candidate.toLowerCase()))
+        const newCandidates = {}
+        for (const user in poll.candidates) {
+            if (Object.hasOwnProperty.call(poll.candidates, user) && winner.some(w => w.answer.toLowerCase() === poll.candidates[user].candidate.toLowerCase())) {
+                newCandidates[user] = poll.candidates[user]
+            }
+        }
+
+        poll.candidates = newCandidates
+
         const response = await createStrawPoll(poll)
         poll.strawPollId = response.data.content_id
 

--- a/classes/Poll.js
+++ b/classes/Poll.js
@@ -23,6 +23,10 @@ class Poll {
         return this.#candidates
     }
 
+    set candidates(candidates) {
+        this.#candidates = candidates
+    }
+
     addCandidate(username, candidate) {
         this.#candidates[username] = candidate
     }

--- a/helpers/strawpoll.js
+++ b/helpers/strawpoll.js
@@ -1,4 +1,5 @@
 const { STRAWPOLL_KEY } = require('../config.json')
+const { Poll } = require('../classes')
 const axios = require('axios').default
 
 const STRAWPOLL_URL = 'https://strawpoll.com/api/poll'
@@ -7,7 +8,7 @@ const headers = { 'API-KEY': STRAWPOLL_KEY }
 /**
  * Create a StrawPoll for the given Poll using the StrawPoll API.
  * https://strawpoll.com/api-docs
- * @param {object} poll The Poll object holding all Poll information
+ * @param {Poll} poll The Poll object holding all Poll information
  */
 function createStrawPoll(poll) {
     const body = {


### PR DESCRIPTION
## Summary
After a couple months of using Clotho, we realized that we were getting into a lot more "tiebreaker" situations than we had anticipated. Until now, we had been manually creating new polls with only the tied candidates.

This PR is to automate that process, so that if there is a tie, a new StrawPoll will be created automatically and posted in the same text channel.

This PR closes #11.

If accepted, this PR will:
- Clean up a couple small areas of code
- Create tiebreaker StrawPolls whenever two or more candidates tie for votes on the original

**NOTE:** Tiebreaker polls will be created *infinitely* until a single winner is found! 

## How to Test
1. Get a buddy, preferably 2
2. Pull down this branch and run `yarn && yarn start`
3. In your Discord server that Clotho is a part of, start a new poll with `startpoll Test Poll`
4. Have you and your buddy(ies) each submit something with `!!submit A Thing`
5. Close the poll using `!!closepoll`
5. Have an even number of you vote the same amount on different candidates, so that there is a clear tie
   * For example, if there are 2 of you, each of you apply 1 vote on separate candidates
6. Take note of the tied candidate names
7. Run the `!!declare` command
8. Clotho should send a message explaining that there has been a tie and that you should vote again on a new StrawPoll that will appear below
9. Another new StrawPoll with *only* the tied candidates should be created and posted in the channel
10. If they tie again and you run `!!declare`, the same thing should happen
11. If there is a clear winner and you run `!!declare`, it should declare the correct candidate as the victor and close out the poll

## Suggested Reading
- [StrawPoll API Docs](https://strawpoll.com/api-docs/)
