### PR TITLE
ALL-21: Throw Error If Candidate is Submitted After Closing Poll

### DIFF
--- a/actions/submit.js
+++ b/actions/submit.js
@@ -17,7 +17,7 @@ async function validate(poll, message, candidate) {
         throw new Error('No candidate was provided! Please use the **!!help** command to see proper usage')
     }
 
-    if (poll.strawPollId){
+    if (poll.isClosed){
         throw new Error('This poll has been closed, so your candidate cannot be received right now. Please start a new poll with the *!!startpoll* command.')
     }
 

--- a/actions/submit.js
+++ b/actions/submit.js
@@ -17,6 +17,10 @@ async function validate(poll, message, candidate) {
         throw new Error('No candidate was provided! Please use the **!!help** command to see proper usage')
     }
 
+    if (poll.strawPollId){
+        throw new Error('This poll has been closed, so your candidate cannot be received right now. Please start a new poll with the *!!startpoll* command.')
+    }
+
     const duplicateSubmissions = Object.keys(poll.candidates)
         .filter(user => user !== message.author.username)
         .filter(user => poll.candidates[user].candidate.toLowerCase() === candidate.toLowerCase())

--- a/classes/Poll.js
+++ b/classes/Poll.js
@@ -1,14 +1,18 @@
 class Poll {
-    #title = ''
-    #strawPollId = ''
     #candidates = {}
+    #strawPollId = ''
+    #title = ''
 
-    get title() {
-        return this.#title
+    get candidates() {
+        return this.#candidates
     }
 
-    set title(title) {
-        this.#title = title
+    set candidates(candidates) {
+        this.#candidates = candidates
+    }
+
+    get isClosed() {
+        return !!this.#strawPollId
     }
 
     get strawPollId() {
@@ -19,12 +23,12 @@ class Poll {
         this.#strawPollId = pollId
     }
 
-    get candidates() {
-        return this.#candidates
+    get title() {
+        return this.#title
     }
 
-    set candidates(candidates) {
-        this.#candidates = candidates
+    set title(title) {
+        this.#title = title
     }
 
     addCandidate(username, candidate) {


### PR DESCRIPTION
## Summary
This PR is being made to cover a case in the [state transition matrix](https://github.com/ShowMeTheRoapes/clotho/wiki/State-Transitions) that was missed - a user should not be able to submit a candidate after the poll has closed.

If accepted, this PR will:
- Throw an error explaining why the user's candidate cannot be accepted when the poll is closed
- Refactor the Poll class to sort object properties alphabetically

## How to Test
1. `yarn && yarn start`
2. Start a poll using the `!!startpoll` command (run `!!help` for usage)
3. Submit a candidate using the `!!submit` command
4. Close the poll using the `!!closepoll` command
5. Try submitting another candidate using the `!!submit` command
6. You should receive an error explaining that the poll has already been closed and it will not accept your candidate